### PR TITLE
add rebuild command for fixing version mismatch errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,30 +4,43 @@ patchwork-electron
 
 ## Running from source
 
-```
-cd ~
-git clone https://github.com/ssbc/patchwork-electron.git
-cd patchwork-electron
-npm install
-npm start
+```bash
+$ cd ~
+$ git clone https://github.com/ssbc/patchwork-electron.git
+$ cd patchwork-electron
+$ npm install
+$ npm start
 ```
 
 To use the latest patchwork version, do the following:
 
+```bash
+$ cd ~
+$ git clone https://github.com/ssbc/patchwork.git
+$ cd patchwork
+$ npm install
+$ npm link
+$ cd ~/patchwork-electron/app
+$ npm link ssb-patchwork
 ```
-cd ~
-git clone https://github.com/ssbc/patchwork.git
-cd patchwork
-npm install
-npm link
-cd ~/patchwork-electron/app
-npm link ssb-patchwork
+
+## Troubleshooting
+
+If you get an error similar to:
+
+> Uncaught Exception:
+> Error: Module version mismatch. Expected 50, got 48.
+
+It means your installed node version is not compatible with the version of Electron patchwork uses. You'll need to rebuild your node module folder using:
+
+```bash
+$ npm run rebuild
 ```
 
 ## Building
 
-```
-npm run release
+```bash
+$ npm run release
 ```
 
 ## More info

--- a/package.json
+++ b/package.json
@@ -2,10 +2,12 @@
   "devDependencies": {
     "asar": "^0.7.2",
     "electron-prebuilt": "~1.1.3",
+    "electron-rebuild": "^1.2.1",
     "fs-jetpack": "^0.7.0",
     "gulp": "^3.9.0",
     "gulp-less": "^3.0.3",
     "gulp-util": "^3.0.6",
+    "prebuild": "^4.2.2",
     "q": "^1.4.1",
     "rollup": "^0.21.0",
     "tree-kill": "^0.1.1",
@@ -17,6 +19,7 @@
   },
   "scripts": {
     "postinstall": "cd app && npm install",
+    "rebuild": "electron-rebuild --module-dir app/node_modules && electron ./tasks/rebuild-prebuild",
     "release": "gulp release --env=production",
     "start": "node ./tasks/start",
     "test": "node ./tasks/start --env=test"

--- a/tasks/rebuild-prebuild.js
+++ b/tasks/rebuild-prebuild.js
@@ -1,0 +1,39 @@
+// run this script with electron
+// needed because electron-rebuild doesn't handle "prebuild" modules like leveldown and sodium
+// based on https://github.com/juliangruber/require-rebuild/blob/master/index.js
+
+'use strict';
+
+var fs = require('fs');
+var join = require('path').join;
+var childProcess = require('child_process');
+var nodeModulesPath = join(__dirname, '..', 'app', 'node_modules');
+
+fs.readdirSync(nodeModulesPath).forEach(function (name) {
+  var dir = join(nodeModulesPath, name);
+  var packageInfo = getPackageInfo(dir);
+  if (checkForPrebuild(packageInfo)) {
+    console.log('rebuild ' + dir)
+    childProcess.spawnSync('prebuild', [
+      '--install',
+      '--abi=' + process.versions.modules,
+      '--target=' + process.versions.node
+    ], {
+      cwd: dir,
+      stdio: 'inherit'
+    });
+  }
+});
+
+process.exit(0);
+
+function getPackageInfo (path) {
+  try {
+    return JSON.parse(fs.readFileSync(join(path, 'package.json')));
+  } catch (ex) {}
+}
+
+function checkForPrebuild (packageInfo) {
+  var reg = /prebuild/;
+  return packageInfo && packageInfo.scripts && (reg.test(packageInfo.scripts.install) || reg.test(packageInfo.scripts.prebuild));
+}


### PR DESCRIPTION
I've added [electron-rebuild](https://github.com/electron/electron-rebuild) as a dependency to assist rebuilding the native dependencies when your node version doesn't match the electron version. (which will be nearly always)

Unfortunately it wasn't quite as simple as just doing that. It has to manually rebuild the dependencies that use [prebuild](https://github.com/mafintosh/prebuild). I stole some code from [require-rebuild](https://github.com/juliangruber/require-rebuild), and managed to get it working. 

But it only works if there are prebuilt binaries available, so we can't upgrade to the latest electron yet.

**One question:** Do we want to make this run on `npm install` or is it okay that you have to manually run `npm run rebuild`?
